### PR TITLE
Updated apitest passwords

### DIFF
--- a/src/test/java/edu/ucsb/nceas/ezid/test/EZIDClientTest.java
+++ b/src/test/java/edu/ucsb/nceas/ezid/test/EZIDClientTest.java
@@ -16,7 +16,7 @@ import edu.ucsb.nceas.ezid.EZIDClient;
 public class EZIDClientTest {
 
     private static String USERNAME = "apitest";
-    private static String PASSWORD = "yourpasswordhere";
+    private static String PASSWORD = "apitest";
     private static final String DOISHOULDER = "doi:10.5072/FK2";
 
     protected static Log log = LogFactory.getLog(EZIDClientTest.class);

--- a/src/test/java/edu/ucsb/nceas/ezid/test/EZIDServiceTest.java
+++ b/src/test/java/edu/ucsb/nceas/ezid/test/EZIDServiceTest.java
@@ -46,7 +46,7 @@ import edu.ucsb.nceas.ezid.profile.InternalProfile;
  */
 public class EZIDServiceTest  {
     private static String USERNAME = "apitest";
-    private static String PASSWORD = "yourpasswordhere";
+    private static String PASSWORD = "apitest";
     private static final String DOISHOULDER = "doi:10.5072/FK2";
     private static final String ARKSHOULDER = "ark:/99999/fk4";
     private static EZIDService ezid = null;


### PR DESCRIPTION
Tests fail when you try to build after a new download, but changing the test passwords to "apitest" allows them to succeed.

Is there a reason to not use the test password for the tests?  It's just creating records in the temporary test space, right?