### PR TITLE
release 1.1.0 changes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@
   This work was created by the National Center for Ecological Analysis and
   Synthesis at the University of California Santa Barbara (UCSB).
  
-    Copyright 2011-2014 Regents of the University of California
+    Copyright 2011-2020 Regents of the University of California
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ this snippet should work:
     	<dependency>
     		<groupId>edu.ucsb.nceas</groupId>
 			<artifactId>ezid</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.0.3</version>
 			<type>jar</type>
     	</dependency>
     </dependencies>
@@ -96,6 +96,16 @@ and then run:
 
 which will create the jar file in the target directory. The jar file can then be
 included in applications that wish to access EZID.
+
+To successfully run the tests, you must first provide credentials for an EZID account, which
+will be used in the tests to create test DOIs at EZID (which will be deleted by EZID). The
+test DOIs are in a special reserved testing shoulder and will not affect your other ezid identifiers.
+
+```sh
+export EZID_USER=my-ezid-account
+export EZID_PASS=my-ezid-password
+mvn test
+```
 
 Contact us: knb-help@nceas.ucsb.edu
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,26 @@ this snippet should work:
     	<dependency>
     		<groupId>edu.ucsb.nceas</groupId>
 			<artifactId>ezid</artifactId>
-			<version>1.0.3</version>
+			<version>1.1.0</version>
 			<type>jar</type>
     	</dependency>
     </dependencies>
 ```
 
 We plan to publish the ezid artifacts to Maven Central repositories, but have not gotten there yet.
+
+Java versions
+-------------
+
+Original versions of the `ezid` library were built and compiled against JDK 8, but more recent 
+now have shifted to compiling against JDK 17, 21, and 25. While releases could be compiled
+against different versions of Java, the builds at https://maven.dataone.org target the following versions:
+
+- EZID 1.1.0: Java 25
+- EZID 1.0.3: Java 8
+- EZID 1.0.2: Java 8
+- EZID 1.0.1: Java 8
+- EZID 1.0.0: Java 8
 
 Building the library
 --------------------

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ this snippet should work:
     <repositories>
         <repository>
             <id>dataone.org</id>
-            <url>http://dev-testing.dataone.org/maven</url>
+            <url>https://maven.dataone.org/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@ this snippet should work:
     	<dependency>
     		<groupId>edu.ucsb.nceas</groupId>
 			<artifactId>ezid</artifactId>
-			<version>1.0.3</version>
+			<version>2.0.0-SNAPSHOT</version>
 			<type>jar</type>
     	</dependency>
     </dependencies>

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ this snippet should work:
     	<dependency>
     		<groupId>edu.ucsb.nceas</groupId>
 			<artifactId>ezid</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>1.1.0-SNAPSHOT</version>
 			<type>jar</type>
     	</dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
     	<groupId>org.apache.httpcomponents</groupId>
     	<artifactId>httpclient</artifactId>
-    	<version>4.5.1</version>
+    	<version>4.5.13</version>
     	<type>jar</type>
     	<scope>compile</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>edu.ucsb.nceas</groupId>
   <artifactId>ezid</artifactId>
-  <version>1.0.3</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>ezid</name>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
     	<groupId>junit</groupId>
     	<artifactId>junit</artifactId>
-    	<version>4.10</version>
+    	<version>4.13.1</version>
     	<type>jar</type>
     	<scope>compile</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,39 +16,39 @@
   </properties>
 
   <scm>
-  	<url>https://github.com/NCEAS/ezid.git</url>
+      <url>https://github.com/NCEAS/ezid.git</url>
   </scm>
   <organization>
-  	<name>National Center for Ecological Analysis and Synthesis, UC Santa Barbara</name>
-  	<url>https://nceas.ucsb.edu</url>
+      <name>National Center for Ecological Analysis and Synthesis, UC Santa Barbara</name>
+      <url>https://nceas.ucsb.edu</url>
   </organization>
   <dependencies>
     <dependency>
-    	<groupId>org.apache.httpcomponents</groupId>
-    	<artifactId>httpclient</artifactId>
-    	<version>4.5.1</version>
-    	<type>jar</type>
-    	<scope>compile</scope>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.1</version>
+        <type>jar</type>
+        <scope>compile</scope>
     </dependency>
     <dependency>
-    	<groupId>junit</groupId>
-    	<artifactId>junit</artifactId>
-    	<version>4.13.1</version>
-    	<type>jar</type>
-    	<scope>compile</scope>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.1</version>
+        <type>jar</type>
+        <scope>test</scope>
     </dependency>
   </dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   </scm>
   <organization>
   	<name>National Center for Ecological Analysis and Synthesis, UC Santa Barbara</name>
-  	<url>http://nceas.ucsb.edu</url>
+  	<url>https://nceas.ucsb.edu</url>
   </organization>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <name>ezid</name>
     <description>Utility library for accessing the EZID service for creation and management of unique identifiers.</description>
-    <url>https://github.com/mbjones/ezid</url>
+    <url>https://github.com/NCEAS/ezid</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -52,4 +52,25 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>dataone.org</id>
+            <url>https://maven.dataone.org/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <distributionManagement>
+        <repository>
+            <uniqueVersion>false</uniqueVersion>
+            <id>maven.dataone.org</id>
+            <name>DataONE</name>
+            <url>scp://maven.dataone.org/var/www/maven</url>
+            <layout>default</layout>
+        </repository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,13 @@
                 </configuration>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>3.5.3</version>
+            </extension>
+        </extensions>
     </build>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>25</source>
                     <target>25</target>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>edu.ucsb.nceas</groupId>
     <artifactId>ezid</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>ezid</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>edu.ucsb.nceas</groupId>
   <artifactId>ezid</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>ezid</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,43 +1,44 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>edu.ucsb.nceas</groupId>
-  <artifactId>ezid</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
+    <groupId>edu.ucsb.nceas</groupId>
+    <artifactId>ezid</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-  <name>ezid</name>
-  <description>Utility library for accessing the EZID service for creation and management of unique identifiers.</description>
-  <url>https://github.com/mbjones/ezid</url>
+    <name>ezid</name>
+    <description>Utility library for accessing the EZID service for creation and management of unique identifiers.</description>
+    <url>https://github.com/mbjones/ezid</url>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
-  <scm>
-      <url>https://github.com/NCEAS/ezid.git</url>
-  </scm>
-  <organization>
-      <name>National Center for Ecological Analysis and Synthesis, UC Santa Barbara</name>
-      <url>https://nceas.ucsb.edu</url>
-  </organization>
-  <dependencies>
-    <dependency>
-    	<groupId>org.apache.httpcomponents</groupId>
-    	<artifactId>httpclient</artifactId>
-    	<version>4.5.14</version>
-    	<type>jar</type>
-    	<scope>compile</scope>
-    </dependency>
-    <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.1</version>
-        <type>jar</type>
-        <scope>test</scope>
-    </dependency>
-  </dependencies>
+    <scm>
+        <url>https://github.com/NCEAS/ezid.git</url>
+    </scm>
+    <organization>
+        <name>National Center for Ecological Analysis and Synthesis, UC Santa Barbara</name>
+        <url>https://nceas.ucsb.edu</url>
+    </organization>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>25</source>
+                    <target>25</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/edu/ucsb/nceas/ezid/EZIDService.java
+++ b/src/main/java/edu/ucsb/nceas/ezid/EZIDService.java
@@ -20,7 +20,6 @@
 package edu.ucsb.nceas.ezid;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -36,30 +35,21 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.ClientContext;
 import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.conn.ClientConnectionManager;
-import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
-import org.apache.http.params.HttpParams;
-import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.util.EntityUtils;
 
 import edu.ucsb.nceas.ezid.profile.InternalProfile;

--- a/src/test/java/edu/ucsb/nceas/ezid/test/EZIDClientTest.java
+++ b/src/test/java/edu/ucsb/nceas/ezid/test/EZIDClientTest.java
@@ -14,8 +14,8 @@ import edu.ucsb.nceas.ezid.EZIDClient;
 
 public class EZIDClientTest {
 
-    private static String USERNAME = "apitest";
-    private static String PASSWORD = "apitest";
+    private static String USERNAME = System.getenv("EZID_USER");
+    private static String PASSWORD = System.getenv("EZID_PASS");
     private static final String DOISHOULDER = "doi:10.5072/FK2";
 
     protected static Log log = LogFactory.getLog(EZIDClientTest.class);
@@ -26,6 +26,9 @@ public class EZIDClientTest {
         log.info("Testing asynchronous id creation with " + numTests + " tests. Please be patient...");
         EZIDClient client = new EZIDClient();
         assertNotNull(client);
+        if (USERNAME == null || USERNAME.isEmpty() || PASSWORD == null || PASSWORD.isEmpty()) {
+            fail("EZID_USER or EZID_PASS environment variables are not set. Can't run tests.");
+        }
         boolean success = client.login(USERNAME, PASSWORD);
         assertTrue(success);
         for (int i = 0; i < numTests; i ++) {

--- a/src/test/java/edu/ucsb/nceas/ezid/test/EZIDServiceTest.java
+++ b/src/test/java/edu/ucsb/nceas/ezid/test/EZIDServiceTest.java
@@ -51,8 +51,8 @@ import edu.ucsb.nceas.ezid.profile.InternalProfile;
  * @author Matthew Jones, NCEAS, UC Santa Barbara
  */
 public class EZIDServiceTest  {
-    private static String USERNAME = "apitest";
-    private static String PASSWORD = "apitest";
+    private static String USERNAME = System.getenv("EZID_USER");
+    private static String PASSWORD = System.getenv("EZID_PASS");
     private static final String DOISHOULDER = "doi:10.5072/FK2";
     private static final String ARKSHOULDER = "ark:/99999/fk4";
     private static EZIDService ezid = null;
@@ -63,6 +63,9 @@ public class EZIDServiceTest  {
     @Before
     public void setUp() throws EZIDException {
         ezid = new EZIDService();
+        if (USERNAME == null || USERNAME.isEmpty() || PASSWORD == null || PASSWORD.isEmpty()) {
+            fail("EZID_USER or EZID_PASS environment variables are not set. Can't run tests.");
+        }
         ezid.login(USERNAME, PASSWORD);
     }
 
@@ -172,7 +175,7 @@ public class EZIDServiceTest  {
     public void setAndGetDataCiteXML() {
         String testId = null;
 
-        String[] versions = {"3.1", "4.0"};
+        String[] versions = {"4.0"};
 
         for (String version : versions) {
             try {


### PR DESCRIPTION
This PR introduces changes for release 1.1.0, including:

- Update to Java 25 target
- Remove support for DataCite version 3.x metadata that is no longer allowed in EZID
- refactor POM to support deployments to https://maven.dataone.org
- upgrade httpclient library
- Refactor to move testing credentials to external environment variables